### PR TITLE
Update copyright year to dynamically display the current year

### DIFF
--- a/index.html
+++ b/index.html
@@ -356,7 +356,7 @@ Join the Community now and become a Villager.
         
       </p>
       <p class="copyright">
-        Copyright &copy 2024 Developed by open source. All rights reserved.
+        Copyright &copy <script>document.write(new Date().getFullYear())</script> Developed by open source. All rights reserved.
       </p>
     </div>
   </footer>


### PR DESCRIPTION
Fixed issue #121 

This pull request updates the copyright year in the footer to dynamically display the current year using JavaScript. This ensures that the copyright year is always up to date without manual intervention.





