### PR TITLE
Footer's email placeholder issue fixed

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1415,6 +1415,9 @@ text-align: center;
 text-transform: capitalize;
 width: 300px;
 }
+.subscribe__input:focus::placeholder{
+  visibility: hidden;
+}
 @media only screen and (max-width:768px) { 
 .subscribe__input{padding: 0 50px 0 20px;}
 }

--- a/css/style.css
+++ b/css/style.css
@@ -1415,9 +1415,19 @@ text-align: center;
 text-transform: capitalize;
 width: 300px;
 }
-.subscribe__input:focus::placeholder{
+.subscribe__input:focus::-webkit-input-placeholder {
   visibility: hidden;
 }
+.subscribe__input:focus:-moz-placeholder { 
+  visibility: hidden;
+}
+.subscribe__input:focus::-moz-placeholder { 
+  visibility: hidden;
+}
+.subscribe__input:focus:-ms-input-placeholder { 
+  visibility: hidden;
+}
+
 @media only screen and (max-width:768px) { 
 .subscribe__input{padding: 0 50px 0 20px;}
 }


### PR DESCRIPTION
Hello PA,
I have fixed the placeholder issue in the footer section's input field! Now, when the email field is focused, the placeholder disappears.
<img width="960" alt="final" src="https://github.com/Its-Aman-Yadav/Community-Site/assets/75217324/115baadc-cfdd-4380-88ae-7cf251d08012">
