### PR TITLE
Text visible for discord and linkedIn buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -224,7 +224,7 @@ nav ul li  a:hover{
 
     .home-thumb a.btn {
       text-decoration: none;
-      color: white;
+      color: black;
       padding: 10px 20px;
       margin: 10px;
       border-radius: 5px;
@@ -238,7 +238,6 @@ nav ul li  a:hover{
       margin-left: 15px;
       border-radius: 5px;
     }
-
     .btn-default {
       background-color: #0c0b0b;
       border: none;


### PR DESCRIPTION
#394  fixed.
The text is now visible for discord and linkedIn buttons.
![image](https://github.com/Its-Aman-Yadav/Community-Site/assets/130165687/21c3bfaf-9403-428a-a615-93ace593e57a)
![Screenshot 2024-05-23 190316](https://github.com/Its-Aman-Yadav/Community-Site/assets/130165687/52ffb12e-0610-4cc3-ad39-71bba861a766)
