### PR TITLE
made the title on navbar responsive for mobile

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -359,6 +359,10 @@ a:hover .fab {
     margin-bottom: 0.5rem;
   }
 
+  .logo-text{
+    font-size: x-large;
+  }
+
   .footer_title {
     font-size: 1rem;
     margin-bottom: 0.5rem;


### PR DESCRIPTION
Title :
- Title on navbar is not responsive

Problem Statement :
- When we open the website in mobile, the title (Open Source Village) written on navbar, exceeds the navbar because of its font size.

Solution : 
- I have updated the font-size of the title in media query

Fixes : #443

Before :
![before](https://github.com/Its-Aman-Yadav/Community-Site/assets/143002978/99117585-893b-4752-aa97-b8913d8f891a)

After :
![after](https://github.com/Its-Aman-Yadav/Community-Site/assets/143002978/8d8df8c0-b837-4388-87d5-90fba937e2fa)
