### PR TITLE
[FIX]: Alignment of Services section cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -212,7 +212,7 @@ function topFunction() {
       <div class="row d-grid gap-3">
         <div class="col-md-4 col-sm-6 shadow-lg p-3 mb-5 bg-body-tertiary rounded s-cards">
           <div class="card wow fadeInUp"
-            style="width: 18rem; background-color:white; border-radius: 8px; padding: 20px;" data-wow-delay="0.4s">
+            style="width: 18rem; height: 15rem; background-color:white; border-radius: 8px; padding: 20px;" data-wow-delay="0.4s">
             <div class="wow fadeIn" data-wow-delay="0.2s">
               <div class="card-heading">
                 <h3 class="heading-hover">Open learning</h3>
@@ -226,7 +226,7 @@ function topFunction() {
         </div>
         <div class="col-md-4 col-sm-6 shadow-lg p-3 mb-5 bg-body-tertiary rounded s-cards">
           <div class="card wow fadeInUp" data-wow-delay="0.8s"
-            style="width: 18rem; background-color:white; border-radius: 8px; padding: 20px;">
+            style="width: 18rem; height: 15rem; background-color:white; border-radius: 8px; padding: 20px;">
             <div class="wow fadeIn" data-wow-delay="0.2s">
               <div class="card-heading">
                 <h3 class="heading-hover">Network</h3>
@@ -240,7 +240,7 @@ function topFunction() {
         </div>
         <div class="col-md-4 col-sm-6 shadow-lg p-3 mb-5 bg-body-tertiary rounded s-cards">
           <div class="card wow fadeInUp" data-wow-delay="1.2s"
-            style="width: 18rem; background-color:white; border-radius: 8px; padding: 20px;">
+            style="width: 18rem; height: 15rem; background-color:white; border-radius: 8px; padding: 20px;">
             <div class="wow fadeIn" data-wow-delay="0.2s">
               <div class="card-heading">
                 <h3 class="heading-hover">Mentorship</h3>


### PR DESCRIPTION
Fixes #566 
This PR aligns the cards in the services section.
It would be greatly appreciated if you could assign this PR and also the `gssoc` and `level1` labels could be added to this PR. Thank you for your attention to this matter.

Few images attached for reference:

Before:
![Screenshot 2024-06-04 123254](https://github.com/Its-Aman-Yadav/Community-Site/assets/118645569/a983e83b-0713-43d8-aa72-d9ac90fd0998)

After:
![Screenshot 2024-06-04 123240](https://github.com/Its-Aman-Yadav/Community-Site/assets/118645569/3cae39af-bb5a-4e6d-a993-0af7dfe68a0a)
