### PR TITLE
 Testimonial's Photos make visible

### DIFF
--- a/index.html
+++ b/index.html
@@ -297,47 +297,65 @@ function topFunction() {
                 <i id="left" class="fa-solid fa-angle-left"></i>
                 <ul class="carousell">
                   <li class="cardd">
-                    <div class="img"><img src="images/testi_1.jpg" alt="img" draggable="false"></div>
+                    <div class="img">
+                      <img src="images/testi_1.jpg" alt="images/img-6.jpg" draggable="false">
+                    </div>
                     <h2>Arden Stone</h2>
                     <span>I'm immensely grateful to have found such an inspiring group of people in this community!</span>
                   </li>
                   <li class="cardd">
-                    <div class="img"><img src="images/testi_2.jpeg" alt="img" draggable="false"></div>
+                    <div class="img">
+                      <img src="images/testi_2.jpeg" alt="images/img-5.jpg" draggable="false">
+                    </div>
                     <h2>John Smith</h2>
                     <span>I've been involved with many groups in the past, but none have been as warm and welcoming as this one.</span>
                   </li>
                   <li class="cardd">
-                    <div class="img"><img src="images/testi_3.jpeg" alt="img" draggable="false"></div>
+                    <div class="img">
+                      <img src="images/testi_3.jpeg" alt="images/img-4.jpg" draggable="false">
+                    </div>
                     <h2>Emily Johnson</h2>
                     <span>The connections I've made here have opened up numerous opportunities for collaboration and personal development.</span>
                   </li>
                   <li class="cardd">
-                    <div class="img"><img src="images/img-1.jpg" alt="img" draggable="false"></div>
+                    <div class="img">
+                      <img src="images/img-1.jpg" alt="images/img-3.jpg" draggable="false">
+                    </div>
                     <h2>Blanche Pearson</h2>
                     <span>Being a part of this community has been truly transformative.</span>
                   </li>
                   <li class="cardd">
-                    <div class="img"><img src="images/img-2.jpg" alt="img" draggable="false"></div>
+                    <div class="img">
+                      <img src="images/img-2.jpg" alt="images/img-2.jpg" draggable="false">
+                    </div>
                     <h2>Joenas Brauers</h2>
                     <span> It's incredible to have such a supportive community around me.</span>
                   </li>
                   <li class="cardd">
-                    <div class="img"><img src="images/img-3.jpg" alt="img" draggable="false"></div>
+                    <div class="img">
+                      <img src="images/img-3.jpg" alt="images/img-1.jpg" draggable="false">
+                    </div>
                     <h2>Lariach French</h2>
                     <span>It's amazing to be among such driven people.</span>
                   </li>
                   <li class="cardd">
-                    <div class="img"><img src="images/img-4.jpg" alt="img" draggable="false"></div>
+                    <div class="img">
+                      <img src="images/img-4.jpg" alt="images/testi_1.jpg" draggable="false">
+                    </div>
                     <h2>James Khosravi</h2>
                     <span>I've found endless support and inspiration.</span>
                   </li>
                   <li class="cardd">
-                    <div class="img"><img src="images/img-5.jpg" alt="img" draggable="false"></div>
+                    <div class="img">
+                      <img src="images/img-5.jpg" alt="images/testi_2.jpg" draggable="false">
+                    </div>
                     <h2>Kristina Zasiadko</h2>
                     <span>The connections I've made are invaluable.</span>
                   </li>
                   <li class="cardd">
-                    <div class="img"><img src="images/img-6.jpg" alt="img" draggable="false"></div>
+                    <div class="img">
+                      <img src="images/img-6.jpg" alt="images/testi_3.jpg" draggable="false">
+                    </div>
                     <h2>Donald Horton</h2>
                     <span>This community has changed my life.</span>
                   </li>


### PR DESCRIPTION
issue no #609 
I make all Testimonial's Photos visible.
Also add alt images in the case of any conflict another photo will be display.
I make sure that all photos will be seen without any conflict.

![image](https://github.com/Its-Aman-Yadav/Community-Site/assets/126322584/a14949a7-e518-482b-9c05-5ac457ef3c12)
![image](https://github.com/Its-Aman-Yadav/Community-Site/assets/126322584/e25f4e82-6b1c-449b-80a2-86c404a8ea34)
![image](https://github.com/Its-Aman-Yadav/Community-Site/assets/126322584/bde4138b-9f11-4baa-9858-0307b987ac61)
