### PR TITLE
Feature : contact us in the footer directs to another page

### DIFF
--- a/footer/footer.js
+++ b/footer/footer.js
@@ -105,7 +105,7 @@ class SpecialFooter extends HTMLElement {
               <h3>Contact</h3>
               <div class="contact-details">
                 <div class="links">
-                  <a href="#"><i class="fa fa-message"></i>Contact Us</a>
+                  <a href="contact us.html"><i class="fa fa-message"></i>Contact Us</a>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Fixes #1004 

The 'Contact' link in the navbar already directs users to the contact form on the page. I have ensured the 'Contact Us' link in the footer should lead to a different page with a new form. 