### PR TITLE
Fixed text in light and dark mode in contact form

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3023,16 +3023,20 @@ input[type="text"]:focus {
   outline: none;
   border-color: rgba(255, 201, 8, 0.5);
   box-shadow: 0 0 10px rgba(255, 201, 8, 0.5);
+  color:black !important;
 }
 input[type="email"]:focus {
   outline: none;
   border-color: rgba(255, 201, 8, 0.5);
   box-shadow: 0 0 10px rgba(255, 201, 8, 0.5);
+  color:black !important;
 }
 textarea:focus {
   outline: none;
   border-color: rgba(255, 201, 8, 0.5);
   box-shadow: 0 0 10px rgba(255, 201, 8, 0.5);
+  color:black !important;
+
 }
 .feedback-label {
   font-weight: bold;
@@ -3526,6 +3530,11 @@ body {
     padding: 0.45rem 0.8rem;
   }
 }
-
+body.dark-mode #contactForm input{
+  color:white;
+}
+body.dark-mode #contactForm textarea{
+  color:white;
+}
 
 

--- a/index.html
+++ b/index.html
@@ -1500,6 +1500,7 @@ a.pre-order-btn:hover {
       background-color: #fff;
       border-color: #333;
       outline: none;
+      color:black !important;
     }
 
     .textarea .input {
@@ -1734,6 +1735,7 @@ a.pre-order-btn:hover {
     .feedback-form input[type="email"]:focus,
     .feedback-form textarea:focus {
       outline: none !important;
+      color: black !important;
     }
 
     .feedback-form button[type="submit"] {


### PR DESCRIPTION
fixes #1083 
The text in contact section is not visible in dark mode , I have made it such that it is visible both in light and dark mode and also when we are typing

Before:

https://github.com/user-attachments/assets/6c57a353-37f0-47d3-ae02-27a8858ddff5

After:

https://github.com/user-attachments/assets/c9543890-15c7-496a-abd1-fc6d6a39c9b4

