### PR TITLE
Edit in spacing and grammar

### DIFF
--- a/index.html
+++ b/index.html
@@ -949,7 +949,7 @@ a.pre-order-btn:hover {
         <br><br><br>
         <h1>Open Source Village</h1>
         <h1 class="wow fadeInUp" data-wow-delay="0.4s">Hello, Villager</h1>
-        <h3 class="wow fadeInUp" data-wow-delay="0.6s">We are <strong>Open Source Village</strong></h3>
+        <h3 class="wow fadeInUp" data-wow-delay="0.6s">We are the <strong>Open Source Village</strong></h3>
         <h3 class="wow fadeInUp" data-wow-delay="0.8s"><strong>Join </strong>our community now</h3>
         <a href="https://discord.gg/mM9qFh2uZR" class="btn btn-lg btn-default smoothScroll wow fadeInUp"
           data-wow-delay="1s" style="color:white;">
@@ -1008,6 +1008,7 @@ a.pre-order-btn:hover {
       </div>
     </div>
   </section>
+  <br>
 
   <script>
     // JavaScript to animate the counter


### PR DESCRIPTION
1- The section class = section had overlapping elements so added <br> tag for spacing. 
2- Changed We Are Open Source Village to We are the Open Source Village, in landing page

<img width="959" alt="before page" src="https://github.com/user-attachments/assets/493d8aef-ff42-4f81-964e-17d5a18c6567">


<img width="959" alt="after page" src="https://github.com/user-attachments/assets/6e3de888-4e4d-4b9f-8f52-528cc054a822">

