### PR TITLE
dark mode in licensing page

### DIFF
--- a/licensing.html
+++ b/licensing.html
@@ -194,8 +194,11 @@ video#background-video {
         }
 
         body.dark-mode .license-container {
-            background-color: #1e1e1e;
+            background: #1e1e1e;
             color: #e0e0e0;
+        }
+        body.dark-mode .license-container .copy {
+            color: #ee7f10;
         }
 
         body.dark-mode .license-container h1,


### PR DESCRIPTION
fixes #1101 

before : 


https://github.com/user-attachments/assets/4b3577e1-bf96-4cad-b0dc-b36a65218942

after : 


https://github.com/user-attachments/assets/79b0cecc-727e-44e2-b901-c5f92370ecb2

