### PR TITLE
Added dark mode in open learning webpage

### DIFF
--- a/open-learning.html
+++ b/open-learning.html
@@ -122,7 +122,39 @@
             background: #333;
             background-image: linear-gradient(to right, #ccc, #333, #ccc);
         }
-    
+        body.dark-mode {
+  background: linear-gradient(rgb(39, 39, 41), rgba(74, 74, 87, 0.979));
+    color: #fff;
+}
+body.dark-mode .main-content{
+  background: linear-gradient(rgb(39, 39, 41), rgba(74, 74, 87, 0.979));
+    color: #fff;
+    box-shadow: 0 4px 15px rgba(255, 255, 255, 0.8) !important;
+}
+body.dark-mode .main-content p{
+color: white;
+}
+body.dark-mode .main-content h1{
+color: white;
+}
+body.dark-mode .cards p{
+  color: black;
+}
+body.dark-mode .card-2{
+  background: linear-gradient(rgb(39, 39, 41), rgba(74, 74, 87, 0.979));
+    color: #fff;
+}
+body.dark-mode .items {
+  background: linear-gradient(rgb(39, 39, 41), rgba(74, 74, 87, 0.979));
+    color: white;
+}
+body.dark-mode .items p{
+  color: white;
+}
+body.dark-mode .learning-card{
+  background: linear-gradient(rgb(39, 39, 41), rgba(74, 74, 87, 0.979));
+    color: #fff;
+}
 </style>
 </head>
 


### PR DESCRIPTION
fixes #1103 
Added dark mode in open learning webpage

Before :

https://github.com/user-attachments/assets/e7ec5883-8967-4631-ad8e-eaac1225e80e

After:


https://github.com/user-attachments/assets/774eb3c9-d845-4179-8a2d-45544a488977