### PR TITLE
BUG: Dark Mode Button Not Responsive

### DIFF
--- a/index.html
+++ b/index.html
@@ -702,7 +702,7 @@ a.pre-order-btn:hover {
         <li><i class="fa-solid fa-right-to-bracket"></i><a href="login.html">Login/Register</a></li>
       </ul>
 
-      <div class="toggle-container" style="top: 15px;">
+      <div class="toggle-container" style="top: 0px;">
         <input type="checkbox" id="checkbox" class="switch-checkbox">
         <label class="theme-switch" for="checkbox">
           <div class="toggle-button">
@@ -833,7 +833,7 @@ a.pre-order-btn:hover {
           display: flex;
           align-items: center;
           justify-content: center;
-          margin-top: 30px;
+          margin: 30px 0 0 30px;
           right: -4px;
           top: 15px;
         }


### PR DESCRIPTION
Fixes #1109 
**Description:**
The dark mode button is not responsive.

**Steps to Reproduce:**

- Navigate to the main page of the application.
- Locate the dark mode button in the header.
- Click on the dark mode button.

**Screenshots/Video:**
If applicable, add screenshots or a video to help explain your problem.
![image](https://github.com/user-attachments/assets/be4f1222-3d54-4ffd-a882-33b18bfd9a46)

**Environment:**

- OS: [e.g., Windows 10, macOS 11.2]
- Browser: [e.g., Chrome 91, Firefox 89]
- Version: [e.g., v1.0.0]
