### PR TITLE
Fix visibility of icons in Navigation Bar for Dark Mode

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1157,6 +1157,11 @@ footer hr {
   /* Hover color in dark mode */
 }
 
+body.dark-mode .fa-solid{
+  color: #ffffff ;
+  /* Text color in dark mode */
+}
+
 /* Responsive Styles */
 @media (max-width: 768px) {
   .footer_wrapper {

--- a/css/style.css
+++ b/css/style.css
@@ -601,6 +601,10 @@ body.dark-mode .navbar nav.sticky {
   background: linear-gradient(rgb(6, 2, 36), rgba(3, 4, 70, 0.7));
   backdrop-filter: blur(6px);
 }
+body.dark-mode .navbar nav.sticky {
+  background: linear-gradient(rgb(6, 2, 36), rgba(3, 4, 70, 0.7));
+  backdrop-filter: blur(6px);
+}
 body.dark-mode .card1 .card-text {
   color: #fff;
 }
@@ -1158,7 +1162,7 @@ footer hr {
 }
 
 body.dark-mode .fa-solid{
-  color: #ffffff ;
+  color: #ffffff !important;
   /* Text color in dark mode */
 }
 
@@ -1743,10 +1747,10 @@ div.card {
   padding: 10px 0px;
 }
 .navbar nav ul li i {
-  filter: invert(1);
+  color: white;
 }
 .navbar nav.sticky ul li i {
-  filter: invert(0);
+  color: black;
 }
 
 .navbar .logo {


### PR DESCRIPTION
Currently, when switching the application interface to dark mode, the icons in the navigation bar become invisible or poorly contrasted against the background. This issue adversely affects user experience by making navigation difficult, especially in low-light conditions or when users prefer darker themes.

fixed #1107 

![image](https://github.com/user-attachments/assets/c4bb6f10-2928-4116-9bc2-e3fe8e4d5505)
