### PR TITLE
Added dark mode for support page

### DIFF
--- a/support.css
+++ b/support.css
@@ -748,6 +748,97 @@ main {
   background-color: #ffa12f;
 }
 
+/* Dark Mode styles */
+
+body.dark-mode {
+  background: #1a1a1a;
+}
+
+body.dark-mode main {
+  background: #333;
+}
+
+body.dark-mode .general {
+  /* background: linear-gradient(to top, #333, #555); */
+  background: #555;
+  box-shadow: 0px 2px 4px rgba(255, 255, 255, 0.1);
+}
+
+body.dark-mode .general h2 {
+  color: #ffd700;
+}
+
+body.dark-mode .general p {
+  color: #ddd;
+}
+
+body.dark-mode .faq h2{
+  color: #ffd700;
+}
+
+body.dark-mode .faq-question {
+  background: linear-gradient(to left, #444, #333);
+  color: #fff;
+}
+
+body.dark-mode .faq-answer {
+  background-color: #222;
+}
+
+body.dark-mode .faq-answer p {
+  color: #ddd;
+}
+
+body.dark-mode .faq-question.active {
+  background: linear-gradient(to left, #555, #444);
+}
+
+body.dark-mode .contact-container {
+  background: #333;
+  
+}
+
+body.dark-mode .contact-form-container {
+  background: linear-gradient(to bottom right, #444, #333);
+}
+
+body.dark-mode .contact-form-container h2 {
+  color: #ffd700;
+}
+
+body.dark-mode .contact-form input,
+body.dark-mode .contact-form textarea {
+  background: #222;
+  color: #fff;
+  border: 1px solid #555;
+}
+
+body.dark-mode .contact-form button {
+  background: #ffd700;
+  color: #000;
+}
+
+body.dark-mode .contact-form button:hover {
+  background: #ffea00;
+}
+
+body.dark-mode .contact-info {
+  background: #222;
+}
+
+body.dark-mode .contact-info h2,
+body.dark-mode .contact-info p {
+  color: #fff;
+}
+
+body.dark-mode .contact-info i {
+  color: #ffd700;
+}
+
+body.dark-mode .contact-form:before {
+  display: none;
+}
+
 /* Media Queries */
 @media (max-width: 768px) {
   .contact-container {

--- a/support.html
+++ b/support.html
@@ -437,6 +437,27 @@
     });
   </script>
 
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      const toggleButton = document.getElementById('checkbox');
+      const currentMode = localStorage.getItem('dark-mode');
+      if (currentMode === 'enabled') {
+        document.body.classList.add('dark-mode');
+        toggleButton.checked = true;
+      }
+
+      toggleButton.addEventListener('change', function () {
+        document.body.classList.toggle('dark-mode');
+        if (document.body.classList.contains('dark-mode')) {
+          localStorage.setItem('dark-mode', 'enabled');
+        }
+        else {
+          localStorage.setItem('dark-mode', 'disabled');
+        }
+      });
+    });
+  </script>
+
 </body>
 
 </html>


### PR DESCRIPTION
## Description

Fixes #1126 

- Added dark mode styles for body and main content
- Styled general information section for dark mode
- Implemented dark mode for FAQ section
- Applied dark mode to contact form and info section

## Video

https://github.com/user-attachments/assets/24ed3ac7-f46b-43fb-bfd6-791625ec191b

