### PR TITLE
Added dark mode toggle button & implemented dark mode for contact us

### DIFF
--- a/contact us.html
+++ b/contact us.html
@@ -7,6 +7,7 @@
     
   <script src="https://kit.fontawesome.com/90889e6878.js" crossorigin="anonymous"></script>
     <link rel="icon" href="favicon.ico">
+    <link rel="stylesheet" href="contact.css">
     <style>
 body {
     font-family: Arial, sans-serif;
@@ -183,6 +184,10 @@ h4 {
     .address {
         gap: 1rem;
     }
+
+    .toggle-container{
+        right: 10px;
+    }
 }
 
 @media screen and (max-width: 350px) {
@@ -274,6 +279,13 @@ h4 {
     <a href="javascript:history.back()" class="back-button">
         <i class="fas fa-arrow-left"></i> Go Back
     </a>
+
+    <div class="toggle-container" style="top: 15px;">
+        <div class="toggle-button">
+          <img src="./images/sun.svg" class="light-mode-icon" alt="Light mode">
+          <img src="./images/moon.svg" class="dark-mode-icon" alt="Dark mode">
+        </div>
+      </div>
 
     <div class="container">
         <div class="card">
@@ -374,5 +386,21 @@ h4 {
 });
 
     </script>
-    </body>
-    </html>
+    
+    <script>
+        const toggleButton = document.querySelector('.toggle-button');
+        const body = document.body;
+      
+        toggleButton.addEventListener('click', () => {
+          body.classList.toggle('dark-mode');
+          localStorage.setItem('darkMode', body.classList.contains('dark-mode'));
+        });
+      
+        // Check for saved dark mode preference
+        if (localStorage.getItem('darkMode') === 'true') {
+          body.classList.add('dark-mode');
+        }
+      </script>
+
+</body>
+</html>

--- a/contact.css
+++ b/contact.css
@@ -1,0 +1,103 @@
+
+  
+  /* Toggle button styles */
+  .toggle-container {
+    position: absolute;
+    display: inline-block;
+    width: 60px;
+    height: 34px;
+    right: 40px;
+    top: 10px;
+  }
+  
+  .toggle-button {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: #ccc;
+    transition: .4s;
+    border-radius: 34px;
+  }
+  
+  .toggle-button:before {
+    position: absolute;
+    content: "";
+    height: 26px;
+    width: 26px;
+    left: 4px;
+    bottom: 4px;
+    background-color: white;
+    transition: .4s;
+    border-radius: 50%;
+  }
+  
+  body.dark-mode .toggle-button {
+    background-color: #2196F3;
+  }
+  
+  body.dark-mode .toggle-button:before {
+    transform: translateX(26px);
+  }
+  
+  .light-mode-icon, .dark-mode-icon {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 20px;
+    height: 20px;
+  }
+  
+  .light-mode-icon {
+    left: 5px;
+  }
+  
+  .dark-mode-icon {
+    right: 5px;
+  }
+  
+  body:not(.dark-mode) .dark-mode-icon,
+  body.dark-mode .light-mode-icon {
+    display: none;
+  }
+
+  
+  /* Dark mode styles */
+  body.dark-mode {
+    background: #1a1a1a;
+  }
+  
+  body.dark-mode .card {
+    background: #333;
+    box-shadow: 0 0 10px rgba(255, 255, 255, 0.1);
+    color: #ffffff;
+  }
+
+  body.dark-mode .back-button,
+  body.dark-mode .back-button i{
+    color: #f1c11a !important;
+  }
+
+  body.dark-mode .usersubmit input{
+    background-color: #f1c11a;
+    color: black;
+  }
+
+  body.dark-mode .form input::placeholder{
+    color: #ccc;
+  }
+
+  body.dark-mode .form textarea::placeholder{
+    color: #ccc;
+  }
+
+  body.dark-mode .address p,
+  body.dark-mode .social i{
+    color: #f1c11a !important;
+  }
+
+  body.dark-mode .social i:hover{
+    color: #eedd9f !important;
+  }


### PR DESCRIPTION
## Description

Fixes #1130 

- Added dark mode toggle button to top of `contact us` page
- Created new `contact.css` file with dark mode styles
- Implemented light/dark mode switching functionality
- Added persistent dark mode preference using localStorage

## Screenshots

 - Old:
 
![light](https://github.com/user-attachments/assets/eec1e2a7-cd0a-4355-8c37-4a1c309cb9f4)

 
 - New:

![dark](https://github.com/user-attachments/assets/46e5afca-9d57-4659-8829-3ae42bf3804b)
