### PR TITLE
tex not visible in dark mode

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -4037,3 +4037,6 @@ body.dark-mode .offering p {
 #acceptCookies:hover{
   background-color: #e22d00;
 }
+body.dark-mode h5{
+  color: white;
+}


### PR DESCRIPTION
fixes #1329 

before : 

![Screenshot 2024-08-04 015115](https://github.com/user-attachments/assets/abc07eee-1128-46e7-be66-ad33e96d242e)
![Screenshot 2024-08-04 015952](https://github.com/user-attachments/assets/aed956f8-233e-4137-aeb7-1f5a4abb5ce8)

after : 


![Screenshot 2024-08-04 020315](https://github.com/user-attachments/assets/a116b8e6-7180-4975-9044-bacf89c36f7e)
![Screenshot 2024-08-04 020326](https://github.com/user-attachments/assets/0c5ab2bb-2ec4-4484-aac4-5e231f8671b1)


