### PR TITLE
Fix Darkmode and User image overlapping in small size in all pages

### DIFF
--- a/about us.html
+++ b/about us.html
@@ -86,6 +86,21 @@
       transform: rotate(-90deg);
       transform-origin: 50% 50%;
     }
+  @media (max-width: 768px) 
+  {
+  .theme-switch,
+  #checkbox 
+  {
+    opacity: 0;
+    pointer-events: none; 
+  }
+
+  #image 
+  {
+    opacity: 0;
+    pointer-events: none; 
+  }
+}
   </style>
 </head>
 

--- a/licensing.html
+++ b/licensing.html
@@ -64,7 +64,21 @@
       .license-container p {
         color: #666;
       }
-
+      @media (max-width: 768px) 
+      {
+      .theme-switch,
+      #checkbox 
+      {
+        opacity: 0;
+        pointer-events: none; 
+      }
+    
+      #image 
+      {
+        opacity: 0;
+        pointer-events: none; 
+      }
+    }
       /* Media query for smaller devices */
       @media (max-width: 768px) {
         .license-container {

--- a/member.html
+++ b/member.html
@@ -197,6 +197,21 @@
         transform: translateX(13px);
         /* background-color: #34495e; */
       }
+      @media (max-width: 768px) 
+      {
+      .theme-switch,
+      #checkbox 
+      {
+        opacity: 0;
+        pointer-events: none; 
+      }
+    
+      #image 
+      {
+        opacity: 0;
+        pointer-events: none; 
+      }
+    }
 
     </style>
 

--- a/mentorship.html
+++ b/mentorship.html
@@ -316,7 +316,21 @@ video#background-video {
         max-width: 100%;
       }
     }
-    
+    @media (max-width: 768px) 
+    {
+    .theme-switch,
+    #checkbox 
+    {
+      opacity: 0;
+      pointer-events: none; 
+    }
+  
+    #image 
+    {
+      opacity: 0;
+      pointer-events: none; 
+    }
+  }
 /* Adjustments for small screens */
 @media (max-width: 768px) {
   

--- a/network.html
+++ b/network.html
@@ -488,6 +488,21 @@ body {
         left: 0;
     }
 }
+@media (max-width: 768px) 
+{
+.theme-switch,
+#checkbox 
+{
+  opacity: 0;
+  pointer-events: none; 
+}
+
+#image 
+{
+  opacity: 0;
+  pointer-events: none; 
+}
+}
 /* dark mode */
 body.dark-mode {
   background: linear-gradient(rgb(39, 39, 41), rgba(74, 74, 87, 0.979));

--- a/open-learning.html
+++ b/open-learning.html
@@ -218,6 +218,21 @@ body.dark-mode .learning-card{
   background: linear-gradient(rgb(39, 39, 41), rgba(74, 74, 87, 0.979));
     color: #fff;
 }
+@media (max-width: 768px) 
+{
+.theme-switch,
+#checkbox 
+{
+  opacity: 0;
+  pointer-events: none; 
+}
+
+#image 
+{
+  opacity: 0;
+  pointer-events: none; 
+}
+}
 </style>
 </head>
 

--- a/our plan.html
+++ b/our plan.html
@@ -225,7 +225,21 @@ video#background-video {
       transform: rotate(-90deg);
       transform-origin: 50% 50%;
     }
-
+    @media (max-width: 768px) 
+    {
+    .theme-switch,
+    #checkbox 
+    {
+      opacity: 0;
+      pointer-events: none; 
+    }
+  
+    #image 
+    {
+      opacity: 0;
+      pointer-events: none; 
+    }
+  }
    
   </style>
 

--- a/our program.html
+++ b/our program.html
@@ -84,7 +84,21 @@
     transform: rotate(-90deg);
     transform-origin: 50% 50%;
   }
+  @media (max-width: 768px) 
+  {
+  .theme-switch,
+  #checkbox 
+  {
+    opacity: 0;
+    pointer-events: none; 
+  }
 
+  #image 
+  {
+    opacity: 0;
+    pointer-events: none; 
+  }
+}
   
 </style>
 </head>

--- a/privacypolicy.html
+++ b/privacypolicy.html
@@ -162,6 +162,21 @@
         #last-updated-date {
           font-size: 19px;
         }
+        @media (max-width: 768px) 
+        {
+        .theme-switch,
+        #checkbox 
+        {
+          opacity: 0;
+          pointer-events: none; 
+        }
+      
+        #image 
+        {
+          opacity: 0;
+          pointer-events: none; 
+        }
+      }
 
 
     </style>

--- a/support.html
+++ b/support.html
@@ -72,7 +72,21 @@
       transform: rotate(-90deg);
       transform-origin: 50% 50%;
     }
-      
+    @media (max-width: 768px) 
+    {
+    .theme-switch,
+    #checkbox 
+    {
+      opacity: 0;
+      pointer-events: none; 
+    }
+  
+    #image 
+    {
+      opacity: 0;
+      pointer-events: none; 
+    }
+  }
   </style>
    <link rel="stylesheet" href="css/support.css" />
 

--- a/terms&conditions.html
+++ b/terms&conditions.html
@@ -273,7 +273,22 @@
         #last-updated-date {
           font-size: 19px;
         }
-
+       
+        @media (max-width: 768px) 
+        {
+        .theme-switch,
+        #checkbox 
+        {
+          opacity: 0;
+          pointer-events: none; 
+        }
+      
+        #image 
+        {
+          opacity: 0;
+          pointer-events: none; 
+        }
+      }
 
     </style>
 </head>


### PR DESCRIPTION
Fixes #1324 


In all pages hide darkmode button and user profile in small screen


![image](https://github.com/user-attachments/assets/b462454c-677f-4c67-af98-f4bf5f3701b5)
