### PR TITLE
In Contact Us width of input section solved

### DIFF
--- a/contact us.html
+++ b/contact us.html
@@ -646,7 +646,7 @@
     border: none;
     border-radius: 5px;
     background-color: rgba(255, 255, 255, 0.2);
-    color: #fff;
+    color: black;
     font-size: 16px;
     transition: background-color 0.3s ease;
   }

--- a/contact us.html
+++ b/contact us.html
@@ -92,7 +92,7 @@
       }
 
       .form-container {
-        width: 100%;
+        width: 90%;
         font-size: 20px;
       }
 
@@ -640,7 +640,7 @@
 
   .form input,
   .form textarea {
-    width: 100%;
+    width: 95%;
     padding: 10px;
     margin-bottom: 10px;
     border: none;
@@ -666,6 +666,7 @@
     font-size: 18px;
     cursor: pointer;
     transition: background-color 0.3s ease;
+    margin-left: 10px;
   }
 
   .usersubmit input[type="submit"]:hover {


### PR DESCRIPTION
## Summary

The purpose of this PR is fix width of input section in Contact Us

## Description

In Contact Us -- inside get in touch container the user input section(name,eamil,phone,mess,contact us) have weidth improportion and getting out of boundary and making that the input boxes are getting out of the box
so I solve the issue by resizing the width of input section inside Contact Us.

## Images

![Screenshot 2024-10-02 012624](https://github.com/user-attachments/assets/74b5f6ef-19b5-4d9d-a5a8-cf9ca5b079a4)


## Issue(s) Addressed

_Enter the issue number of the bug(s) that this PR fixes_

- Template should be strictly **Closes <issue_number>**
- Example: Closes #1416 

## Prerequisites

- [x] Have you followed all the [CONTRIBUTING GUIDELINES](https://github.com/Its-Aman-Yadav/Community-Site/blob/main/CONTRIBUITING.md)?
