### PR TITLE
Centering the Get In Touch card in the Contact Us Container

### DIFF
--- a/contact us.html
+++ b/contact us.html
@@ -622,6 +622,7 @@
     color: #fff;
     font-size: 28px;
     margin-bottom: 20px;
+    margin-left: 110px;
   }
 
   .form-container {


### PR DESCRIPTION
## Summary

Centering the Get In Touch card in the Contact Us Container

## Description

Centering the Get In Touch card in the Contact Us Container by changing the margin in CSS and now it is in center of the contact Us page

## Images

![Screenshot 2024-10-02 144047](https://github.com/user-attachments/assets/12cb16ee-3bd6-41f4-ae89-fe112d384521)


## Issue(s) Addressed

_Enter the issue number of the bug(s) that this PR fixes_

- Template should be strictly **Closes <issue_number>**
- Example: Closes #1408 

## Prerequisites

- [x] Have you followed all the [CONTRIBUTING GUIDELINES](https://github.com/Its-Aman-Yadav/Community-Site/blob/main/CONTRIBUITING.md)?
