### PR TITLE
dark mode in FAQ fix

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -677,6 +677,13 @@ body.dark-mode .accordion .accordion-content p {
   margin: 20px 0;
 }
 
+body.dark-mode .accordion span {
+  color: white;
+}
+body.dark-mode .accordion{
+  background-color: rgba( 0,0,0,0.8);
+}
+
 body.dark-mode .accordion-content {
   background: #003973;
   background: -webkit-linear-gradient(to right, #e5e5be, #003973);
@@ -779,6 +786,7 @@ h2 {
   padding: 0px 15px;
   flex-direction: row;
   justify-content: space-between;
+  color: black;
 }
 
 /* Accordion Button */
@@ -4077,3 +4085,4 @@ body.dark-mode .offering h4{
 body.dark-mode h5{
   color: white;
 }
+


### PR DESCRIPTION
## Summary

In dark-mode the background become black and text become white but in FAQ section its background is still white and text of same color as in light theme.
so I changed the the background to black and text white that will be comfortable for user.

## Description

In dark-mode the background become black and text become white but in FAQ section its background is still white and text of same color as in light theme.
so I changed the the background to black and text white that will be comfortable for user. 
Now user have better experience with this site.

## Images

![Screenshot 2024-10-07 011934](https://github.com/user-attachments/assets/e9ab8ec7-fb07-42e6-91d2-b04df9349c7c)


## Issue(s) Addressed

_Enter the issue number of the bug(s) that this PR fixes_

- Template should be strictly **Closes <issue_number>**
- Example: Closes #1468 

## Prerequisites

- [x] Have you followed all the [CONTRIBUTING GUIDELINES](https://github.com/Its-Aman-Yadav/Community-Site/blob/main/CONTRIBUITING.md)?
